### PR TITLE
Update ORM extension installation method to use env vars

### DIFF
--- a/commands/contentbox/install.cfc
+++ b/commands/contentbox/install.cfc
@@ -200,8 +200,8 @@ component {
 		command( "server set app.cfengine=#arguments.cfmlEngine#" ).run();
 		command( "server set web.rewrites.enable=true" ).run();
 		command( "server set jvm.heapsize=768" ).run();
-		command( "server set jvm.args=-Dfile.encoding=UTF8 -Dcom.sun.net.ssl.enableECC=false" ).run();
-		command( "server set env.lucee-extensions=D062D72F-F8A2-46F0-8CBC91325B2F067B" ).run();
+		command( "server set jvm.args='-Dfile.encoding=UTF8 -Dcom.sun.net.ssl.enableECC=false'" ).run();
+		command( "server set env.lucee-extensions='D062D72F-F8A2-46F0-8CBC91325B2F067B'" ).run();
 
 		// 2021+ cfpm installs
 		if ( arguments.cfmlEngine.findNoCase( "adobe@202" ) ) {

--- a/commands/contentbox/install.cfc
+++ b/commands/contentbox/install.cfc
@@ -200,7 +200,8 @@ component {
 		command( "server set app.cfengine=#arguments.cfmlEngine#" ).run();
 		command( "server set web.rewrites.enable=true" ).run();
 		command( "server set jvm.heapsize=768" ).run();
-		command( "server set jvm.args=-Dfile.encoding=UTF8 -Dcom.sun.net.ssl.enableECC=false -Dlucee-extensions=D062D72F-F8A2-46F0-8CBC91325B2F067B" ).run();
+		command( "server set jvm.args=-Dfile.encoding=UTF8 -Dcom.sun.net.ssl.enableECC=false" ).run();
+		command( "server set env.lucee-extensions=D062D72F-F8A2-46F0-8CBC91325B2F067B" ).run();
 
 		// 2021+ cfpm installs
 		if ( arguments.cfmlEngine.findNoCase( "adobe@202" ) ) {

--- a/commands/contentbox/install.cfc
+++ b/commands/contentbox/install.cfc
@@ -201,7 +201,7 @@ component {
 		command( "server set web.rewrites.enable=true" ).run();
 		command( "server set jvm.heapsize=768" ).run();
 		command( "server set jvm.args='-Dfile.encoding=UTF8 -Dcom.sun.net.ssl.enableECC=false'" ).run();
-		command( "server set env.lucee-extensions='D062D72F-F8A2-46F0-8CBC91325B2F067B'" ).run();
+		command( "server set env.LUCEE-EXTENSIONS='D062D72F-F8A2-46F0-8CBC91325B2F067B'" ).run();
 
 		// 2021+ cfpm installs
 		if ( arguments.cfmlEngine.findNoCase( "adobe@202" ) ) {


### PR DESCRIPTION
# Description

It seems CommandBox is not correctly passing the jvm args to Lucee, hence the extension installation fails (and thus ContentBox installation fails.)

This PR updates the contentbox CLI to install extensions via an env var, as the env var method still works and seems more bulletproof.

## Issues

[All PRs must have an accompanied issue. Please make sure you created it and linked it here.](https://ortussolutions.atlassian.net/browse/CONTENTBOX-1504)

## Type of change

Please delete options that are not relevant.

- [X] Bug Fix

## Checklist

- [X] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
