### PR TITLE
v1.6.0

### DIFF
--- a/box.json
+++ b/box.json
@@ -1,6 +1,6 @@
 {
     "name":"ContentBox CLI",
-    "version":"1.5.2",
+    "version":"1.6.0",
     "location":"https://downloads.ortussolutions.com/ortussolutions/commandbox-modules/contentbox-cli/@build.version@/contentbox-cli-@build.version@.zip",
     "slug":"contentbox-cli",
     "author":"Ortus Solutions, Corp",

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Adobe 2023 Support
+- Lucee 6 Support
+- Dropped Adobe 2016 since this was deprecated already
+- ContentBox 6 default version
+
+### Updates
+
+- Updated Database Drivers for: MySQL, MSSQL, Hypersonic
+
+### Fixed
+
+- ContentBox 6 was not the default and migrations was not running correctly
+
 ## [1.5.2] - 2024-02-16
 
 ### Fixed

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.2] - 2024-02-16
+
 ### Fixed
 
 - Temporary fix for the ORM extension not being discovered due to lucee bug on jvm args.
@@ -87,6 +89,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Misspelling on database port for Microsoft SQL server.
 - `appcfc` missing variable when updating Lucee + MySQL 8 bug for DDL creation.
 
-[Unreleased]: https://github.com/Ortus-Solutions/contentbox-cli/compare/v1.5.1...HEAD
+[Unreleased]: https://github.com/Ortus-Solutions/contentbox-cli/compare/v1.5.2...HEAD
+
+[1.5.2]: https://github.com/Ortus-Solutions/contentbox-cli/compare/v1.5.1...v1.5.2
 
 [1.5.1]: https://github.com/Ortus-Solutions/contentbox-cli/compare/e199c386dc5d1b262f9259d6824df5fa7dfdd77e...v1.5.1

--- a/changelog.md
+++ b/changelog.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ContentBox 6 was not the default and migrations was not running correctly
 
-***
+* * *
 
 ## [1.5.2] - 2024-02-16
 

--- a/commands/contentbox/install-wizard.cfc
+++ b/commands/contentbox/install-wizard.cfc
@@ -33,9 +33,10 @@ component extends="install" {
 					value    : "lucee@5",
 					selected : true
 				},
-				{
-					display : "Adobe 2016",
-					value   : "adobe@2016"
+                {
+					display  : "Lucee 6",
+					value    : "lucee@6",
+					selected : true
 				},
 				{
 					display : "Adobe 2018",
@@ -44,6 +45,10 @@ component extends="install" {
 				{
 					display : "Adobe 2021",
 					value   : "adobe@2021"
+				},
+                {
+					display : "Adobe 2023",
+					value   : "adobe@2023"
 				}
 			] )
 			.ask();

--- a/commands/contentbox/install-wizard.cfc
+++ b/commands/contentbox/install-wizard.cfc
@@ -33,7 +33,7 @@ component extends="install" {
 					value    : "lucee@5",
 					selected : true
 				},
-                {
+				{
 					display  : "Lucee 6",
 					value    : "lucee@6",
 					selected : true
@@ -46,7 +46,7 @@ component extends="install" {
 					display : "Adobe 2021",
 					value   : "adobe@2021"
 				},
-                {
+				{
 					display : "Adobe 2023",
 					value   : "adobe@2023"
 				}

--- a/commands/contentbox/install.cfc
+++ b/commands/contentbox/install.cfc
@@ -20,10 +20,10 @@ component {
 	static {
 		engines = [
 			"lucee@5",
-            "lucee@6",
+			"lucee@6",
 			"adobe@2018",
 			"adobe@2021",
-            "adobe@2023"
+			"adobe@2023"
 		];
 		databases = [
 			"HyperSonicSQL",

--- a/commands/contentbox/install.cfc
+++ b/commands/contentbox/install.cfc
@@ -3,7 +3,7 @@
  *
  * This command is meant to be ran and not expecting user feedback.
  *
- * The supported CFML Engines are "lucee@5", "adobe@2016", "adobe@2018", "adobe@2021"
+ * The supported CFML Engines are "lucee@5", "lucee@6", "adobe@2018", "adobe@2021", "adobe@2023"
  * The supported Databases are: "HyperSonicSQL (Lucee Only)", "MySQL5", "MySQL8", "MicrosoftSQL", "PostgreSQL", "Oracle"
  *
  * .
@@ -20,9 +20,10 @@ component {
 	static {
 		engines = [
 			"lucee@5",
-			"adobe@2016",
+            "lucee@6",
 			"adobe@2018",
-			"adobe@2021"
+			"adobe@2021",
+            "adobe@2023"
 		];
 		databases = [
 			"HyperSonicSQL",
@@ -33,7 +34,7 @@ component {
 			"Oracle"
 		];
 		hypersonicSlug    = "6DD4728A-AB0C-4F67-9DCE1A91A8ACD114";
-		contentboxVersion = "5";
+		contentboxVersion = "6";
 	};
 
 	/**
@@ -359,7 +360,7 @@ component {
 					"DB_CONNECTIONSTRING=jdbc:hsqldb:file:contentboxDB/#arguments.databasename#"
 				);
 				// Setup the jdbc extension
-				command( "server set jvm.args='-Dlucee-extensions=6DD4728A-AB0C-4F67-9DCE1A91A8ACD114'" );
+				command( "server set jvm.args='-Dlucee-extensions=#hypersonicSlug#'" );
 				break;
 			}
 			case "MySQL5": {
@@ -422,7 +423,7 @@ component {
 				env = replaceNoCase(
 					env,
 					"DB_BUNDLEVERSION=",
-					"DB_BUNDLEVERSION=8.0.24"
+					"DB_BUNDLEVERSION=8.1.0"
 				);
 				env = replaceNoCase(
 					env,
@@ -464,7 +465,7 @@ component {
 				env = replaceNoCase(
 					env,
 					"DB_BUNDLEVERSION=",
-					"DB_BUNDLEVERSION=4.0.2206.100"
+					"DB_BUNDLEVERSION=12.4.2.jre11"
 				);
 				env = replaceNoCase(
 					env,


### PR DESCRIPTION
### Added

- Adobe 2023 Support
- Lucee 6 Support
- Dropped Adobe 2016 since this was deprecated already
- ContentBox 6 default version

### Updates

- Updated Database Drivers for: MySQL, MSSQL, Hypersonic

### Fixed

- ContentBox 6 was not the default and migrations was not running correctly